### PR TITLE
Trivial: Update links to MIT license (https).

### DIFF
--- a/ctaes.c
+++ b/ctaes.c
@@ -1,7 +1,7 @@
  /*********************************************************************
  * Copyright (c) 2016 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 /* Constant time, unoptimized, concise, plain C, AES implementation

--- a/ctaes.h
+++ b/ctaes.h
@@ -1,7 +1,7 @@
  /*********************************************************************
  * Copyright (c) 2016 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #ifndef _CTAES_H_

--- a/test.c
+++ b/test.c
@@ -1,7 +1,7 @@
  /*********************************************************************
  * Copyright (c) 2016 Pieter Wuille                                   *
  * Distributed under the MIT software license, see the accompanying   *
- * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ * file COPYING or https://opensource.org/licenses/mit-license.php.   *
  **********************************************************************/
 
 #include "ctaes.h"


### PR DESCRIPTION
Fixes #12. More details in
https://github.com/bitcoin/bitcoin/issues/12190 .