### PR TITLE
Port to windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.10)
+project(ctaes C)
+set(CMAKE_C_STANDARD 90)
+include(GNUInstallDirs REQUIRED)
+
+# pass basic flags to compilers depending on compiler
+if ("${CMAKE_C_COMPILER_ID}" MATCHES "Clang" OR "${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+    set(CMAKE_C_FLAGS "-Wall -Wextra -Wundef -Wpointer-arith -Wconversion" CACHE STRING "C compiler flags" FORCE)
+elseif ("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
+    set(CMAKE_C_FLAGS "/Wall /sdl /MP" CACHE STRING "C compiler flags" FORCE )
+endif()
+message("-- C flags being used: ${CMAKE_C_FLAGS}")
+
+# ctaes library
+add_library(ctaes STATIC ctaes.c ctaes.h)
+
+target_include_directories(ctaes
+        PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+            $<INSTALL_INTERFACE:include>
+)
+
+# tests
+enable_testing()
+add_executable(tests test.c)
+target_link_libraries(tests PRIVATE ctaes)
+add_test(tests tests)  # add test to runner
+
+# bench
+add_executable(bench bench.c)
+target_link_libraries(bench PRIVATE ctaes)
+
+# installation and config file for other CMake projects to import
+# defaults to /usr/local in linux and C:/Program Files(x86) in Windows
+install(TARGETS ctaes EXPORT ctaesConfig
+        ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(FILES ctaes.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(EXPORT ctaesConfig DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ctaes)
+
+# This makes the project importable from the build directory
+export(TARGETS ctaes FILE ctaesConfig.cmake)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Benchmark:
 
     $ gcc -O3 ctaes.c bench.c -o bench
 
-CMake for *nix and windows:
+CMake for all targets:
 
     $ cmake . -B build/ -DCMAKE_BUILD_TYPE=MinSizeRel
     $ cmake --build build/ --config MinSizeRel

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ Benchmark:
 
     $ gcc -O3 ctaes.c bench.c -o bench
 
+CMake for *nix and windows:
+
+    $ cmake . -B build/ -DCMAKE_BUILD_TYPE=MinSizeRel
+    $ cmake --build build/ --config MinSizeRel
+
+
+
 Review
 ------
 

--- a/bench.c
+++ b/bench.c
@@ -5,9 +5,34 @@
  **********************************************************************/
 #include <stdio.h>
 #include <math.h>
-#include "sys/time.h"
 
 #include "ctaes.h"
+
+#ifdef _WIN32
+#include <WinSock2.h>
+#include <stdint.h>
+
+/* gettimeofday is not availabe in windows so define here */
+int gettimeofday(struct timeval * tp, struct timezone * tzp) {
+    static const uint64_t EPOCH = ((uint64_t) 116444736000000000ULL);
+    SYSTEMTIME system_time;
+    FILETIME file_time;
+    uint64_t time;
+
+    GetSystemTime(&system_time);
+    SystemTimeToFileTime(&system_time, &file_time);
+    time = ((uint64_t)file_time.dwLowDateTime);
+    time += ((uint64_t)file_time.dwHighDateTime) << 32;
+
+    tp->tv_sec  = (long) ((time - EPOCH) / 10000000L);
+    tp->tv_usec = (long) (system_time.wMilliseconds * 1000);
+    return 0;
+}
+
+#else
+#include "sys/time.h"
+#endif
+
 
 static double gettimedouble(void) {
     struct timeval tv;


### PR DESCRIPTION
This PR adds a couple changes to port this library to a Windows environment.

#### build system
Added a `CMakeLists.txt` for a simple portable build system across OS's. It has been carefully written and annotated with comments for easy consumption and portability. This lets a user using Windows and *nix-like environment to build this project with a variety of "generators"(Make, Ninja, Visual Studio) and compilers. 

The directory structure created for install looks as follows assuming its installed to the default /usr/local:
```sh
/usr/local/ctaes/
    include/
        ctaes.h   // <-- our header
    lib/
        libctaes.a //   <--- our library
        cmake/
            ctaes/
                 ctaesConfig.cmake    // <--- config for other CMake projects to consume
    
```

The defaults provided by CMake are nearly always right and one could pass specific configs to the terminal on Windows10 with something like, provided you have clang in your path:

```sh
cmake . -DCMAKE_C_COMPILER=clang
```

Lines 35-43 are the "toughest" to digest, but they essentially describe how to install the library and header along with a config file for other CMake projects to consume this library.

#### bench.c
The function `gettimeofday` does not exist within the win32 environment and so to keep the same functionality, we just define an equivalent form of it.

#### README
Shows how to build with CMake.


##### How it looks on Ubuntu via WSL2 (but also tested on standalone ubuntu)
```sh
user@DESKTOP-VCPLNO0:/tmp/ctaes$ cmake . -B build/ -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=./build/output
-- C flags being used: -Wall -Wextra -Wundef -Wpointer-arith -Wconversion
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/ctaes/build
user@DESKTOP-VCPLNO0:/tmp/ctaes$ cmake . -B build/ -DCMAKE_BUILD_TYPE=MinSizeRel
-- C flags being used: -Wall -Wextra -Wundef -Wpointer-arith -Wconversion
-- Configuring done
-- Generating done
-- Build files have been written to: /tmp/ctaes/build
user@DESKTOP-VCPLNO0:/tmp/ctaes$ cmake --install build/
-- Install configuration: "MinSizeRel"
-- Installing: /tmp/ctaes/build/output/lib/libctaes.a
-- Installing: /tmp/ctaes/build/output/include/ctaes.h
-- Installing: /tmp/ctaes/build/output/lib/cmake/ctaes/ctaesConfig.cmake
-- Installing: /tmp/ctaes/build/output/lib/cmake/ctaes/ctaesConfig-minsizerel.cmake
````


##### How it looks on Windows10 using the "Windows Terminal" (a slick wrapper around PowerShell)
```sh
PS C:\Users\user\Downloads\ctaes> cmake . -B build/ -DCMAKE_BUILD_TYPE=MinSizeRel
-- Selecting Windows SDK version 10.0.19041.0 to target Windows 10.0.21376.
-- C flags being used: /Wall /sdl /MP
-- Configuring done
-- Generating done
-- Build files have been written to: C:/Users/william/Downloads/ctaes/build
PS C:\Users\user\Downloads\ctaes> cmake --build build/ --config MinSizeRel
Microsoft (R) Build Engine version 16.9.0+5e4b48a27 for .NET Framework
Copyright (C) Microsoft Corporation. All rights reserved.

  Checking Build System
  Building Custom Rule C:/Users/user/Downloads/ctaes/CMakeLists.txt
  ctaes.vcxproj -> C:\Users\user\Downloads\ctaes\build\MinSizeRel\ctaes.lib
  Building Custom Rule C:/Users/user/Downloads/ctaes/CMakeLists.txt
  bench.vcxproj -> C:\Users\user \Downloads\ctaes\build\MinSizeRel\bench.exe
  Building Custom Rule C:/Users/user/Downloads/ctaes/CMakeLists.txt
  tests.vcxproj -> C:\Users\user\Downloads\ctaes\build\MinSizeRel\tests.exe
  Building Custom Rule C:/Users/user/Downloads/ctaes/CMakeLists.txt
```

For the windows user, they can perform the first step of generating the build files and then open up the "sln" file on their Visual Studio and go down that route as well.