### PR TITLE
Handle zero in print_number()

### DIFF
--- a/bench.c
+++ b/bench.c
@@ -21,7 +21,7 @@ static void print_number(double x) {
     if (y < 0.0) {
         y = -y;
     }
-    while (y < 100.0) {
+    while (0.0 < y && y < 100.0) {
         y *= 10.0;
         c++;
     }


### PR DESCRIPTION
If print_number() in bench.c is called with 0.0, it gets stuck in an infinite loop. This patch fixes that.